### PR TITLE
Fixed typos in config

### DIFF
--- a/keymaps/Rougemoot/applekeeb.kbd
+++ b/keymaps/Rougemoot/applekeeb.kbd
@@ -88,7 +88,7 @@ allow-cmd true
 				@fn  _    _    _              @spc      bspc _    _    _    _    _
 )
 
-(defalias fn (around (layer-toggle functin) fn))	
+(defalias fn (around (layer-toggle function) fn))	
 (deflayer function
         _    f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12
              _    _    _    _    _    _    _    _    _    _    _    _    _


### PR DESCRIPTION
This is a bit annoying when trying to test kmonad on a lot of configs and running it for every `kbd` file in contrib.